### PR TITLE
Fix Turkish localization JSON format

### DIFF
--- a/localization/languages/tr.json
+++ b/localization/languages/tr.json
@@ -146,8 +146,8 @@
     "settingsBlockedRequestCount": {
       "unsafeHTML": "Min şimdiye kadar, <strong></strong> reklam ve takipçi engelledi."
     },
-    "settingsCustomBangs": "Kişiselleştirilebilir Komutlar"
-    "settingsCustomBangsAdd": "Yeni komut ekle"
+    "settingsCustomBangs": "Kişiselleştirilebilir Komutlar",
+    "settingsCustomBangsAdd": "Yeni komut ekle",
     "settingsCustomBangsPhrase": "Cümle (Gerekli)",
     "settingsCustomBangsSnippet": "Açıklama (İsteğe Bağlı)",
     "settingsCustomBangsRedirect": "Yönlendirme URL'si (Gerekli)",


### PR DESCRIPTION
## Summary
- fix missing comma in the Turkish language file which caused build errors

## Testing
- `node - <<'NODE'
const fs=require('fs');
let data=fs.readFileSync('localization/languages/tr.json','utf8');
data=data.replace(/\/\*[^]*?\*\//g,'');
const lines=data.split('\n').map(l=>l.replace(/\s*\/\/.*$/,''));
JSON.parse(lines.join('\n'));
console.log('ok');
NODE` *(fails: Cannot find module 'decomment')*
- `npm run buildMain` *(fails: Could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6840e07e38c08327908271aed9969dcf