### PR TITLE
Fix settings macro button and add step-by-step macros

### DIFF
--- a/css/macroManager.css
+++ b/css/macroManager.css
@@ -20,3 +20,16 @@
   margin-top: 1em;
   gap: 0.5em;
 }
+
+#macro-editor textarea,
+#macro-step-console pre {
+  width: 100%;
+  height: 40vh;
+  margin-top: 0.5em;
+}
+
+.macro-step-controls {
+  display: flex;
+  gap: 0.5em;
+  margin-top: 0.5em;
+}

--- a/index.html
+++ b/index.html
@@ -357,6 +357,24 @@
         <input id="macro-name" type="text" placeholder="Macro name" />
         <button id="macro-record"><span class="i carbon:record"></span></button>
         <button id="macro-play"><span class="i carbon:play"></span></button>
+        <button id="macro-step"><span class="i carbon:chevron-right"></span></button>
+      </div>
+    </div>
+
+    <div id="macro-editor" class="modal" hidden>
+      <h2 class="modal-title">Edit Macro</h2>
+      <button id="macro-editor-close" class="modal-close-button i carbon:close"></button>
+      <textarea id="macro-editor-content" spellcheck="false"></textarea>
+      <button id="macro-editor-save">Save</button>
+    </div>
+
+    <div id="macro-step-console" class="modal" hidden>
+      <h2 class="modal-title">Step Macro</h2>
+      <button id="macro-step-close" class="modal-close-button i carbon:close"></button>
+      <pre id="macro-step-output"></pre>
+      <div class="macro-step-controls">
+        <button id="macro-step-next">Next (y)</button>
+        <button id="macro-step-stop">Stop</button>
       </div>
     </div>
 

--- a/js/macroManager.js
+++ b/js/macroManager.js
@@ -13,7 +13,24 @@ const macroManager = {
   nameInput: document.getElementById('macro-name'),
   recordButton: document.getElementById('macro-record'),
   playButton: document.getElementById('macro-play'),
+  stepButton: document.getElementById('macro-step'),
   closeButton: document.getElementById('macro-close'),
+  editor: {
+    container: document.getElementById('macro-editor'),
+    textarea: document.getElementById('macro-editor-content'),
+    save: document.getElementById('macro-editor-save'),
+    close: document.getElementById('macro-editor-close'),
+    macro: null
+  },
+  stepConsole: {
+    container: document.getElementById('macro-step-console'),
+    output: document.getElementById('macro-step-output'),
+    next: document.getElementById('macro-step-next'),
+    stop: document.getElementById('macro-step-stop'),
+    close: document.getElementById('macro-step-close'),
+    macro: null,
+    index: 0
+  },
   macros: [],
   initialize () {
     macroManager.load()
@@ -29,6 +46,24 @@ const macroManager = {
       const macro = macroManager.macros.find(m => m.name === name)
       if (macro) {
         macroManager.playMacro(macro)
+      }
+    })
+    macroManager.stepButton.addEventListener('click', () => {
+      const name = macroManager.nameInput.value
+      const macro = macroManager.macros.find(m => m.name === name)
+      if (macro) {
+        macroManager.stepThroughMacro(macro)
+      }
+    })
+    macroManager.editor.save.addEventListener('click', macroManager.saveEditor)
+    macroManager.editor.close.addEventListener('click', macroManager.hideEditor)
+    macroManager.stepConsole.next.addEventListener('click', () => macroManager.nextStep())
+    macroManager.stepConsole.stop.addEventListener('click', macroManager.hideStepConsole)
+    macroManager.stepConsole.close.addEventListener('click', macroManager.hideStepConsole)
+    window.addEventListener('keydown', function (e) {
+      if (!macroManager.stepConsole.container.hidden && e.key.toLowerCase() === 'y') {
+        e.preventDefault()
+        macroManager.nextStep()
       }
     })
     macroManager.closeButton.addEventListener('click', macroManager.hide)
@@ -66,9 +101,19 @@ const macroManager = {
       name.textContent = macro.name
       const play = document.createElement('button')
       play.className = 'i carbon:play'
+      play.title = 'Play'
       play.addEventListener('click', () => macroManager.playMacro(macro))
+      const step = document.createElement('button')
+      step.className = 'i carbon:chevron-right'
+      step.title = 'Step'
+      step.addEventListener('click', () => macroManager.stepThroughMacro(macro))
+      const edit = document.createElement('button')
+      edit.className = 'i carbon:edit'
+      edit.title = 'Edit'
+      edit.addEventListener('click', () => macroManager.editMacro(macro))
       const del = document.createElement('button')
       del.className = 'i carbon:trash-can'
+      del.title = 'Delete'
       del.addEventListener('click', () => {
         macroManager.macros = macroManager.macros.filter(m => m !== macro)
         macroManager.save()
@@ -76,6 +121,8 @@ const macroManager = {
       })
       item.appendChild(name)
       item.appendChild(play)
+      item.appendChild(step)
+      item.appendChild(edit)
       item.appendChild(del)
       macroManager.list.appendChild(item)
     })
@@ -98,6 +145,12 @@ const macroManager = {
     document.removeEventListener('click', clickListener, true)
     document.removeEventListener('keydown', keyListener, true)
     macroManager.recordButton.textContent = 'Record'
+    if (!recordingMacro.name || recordingMacro.name === 'macro') {
+      const name = prompt('Macro name:')
+      if (name) {
+        recordingMacro.name = name
+      }
+    }
     macroManager.macros.push(recordingMacro)
     macroManager.save()
     macroManager.renderList()
@@ -119,6 +172,59 @@ const macroManager = {
       }, delay)
       delay += 150
     })
+  },
+  stepThroughMacro (macro) {
+    macroManager.stepConsole.macro = macro
+    macroManager.stepConsole.index = 0
+    macroManager.stepConsole.container.hidden = false
+    macroManager.showStep()
+    modalMode.toggle(true, { onDismiss: macroManager.hideStepConsole })
+  },
+  showStep () {
+    const m = macroManager.stepConsole
+    if (!m.macro || m.index >= m.macro.actions.length) {
+      macroManager.hideStepConsole()
+      return
+    }
+    m.output.textContent = JSON.stringify(m.macro.actions[m.index], null, 2)
+  },
+  nextStep () {
+    const m = macroManager.stepConsole
+    if (!m.macro) return
+    const action = m.macro.actions[m.index]
+    if (action) {
+      macroManager.playMacro({ actions: [action] })
+      m.index++
+      macroManager.showStep()
+    } else {
+      macroManager.hideStepConsole()
+    }
+  },
+  hideStepConsole () {
+    macroManager.stepConsole.container.hidden = true
+    modalMode.toggle(false)
+    macroManager.stepConsole.macro = null
+  },
+  editMacro (macro) {
+    macroManager.editor.macro = macro
+    macroManager.editor.textarea.value = JSON.stringify(macro.actions, null, 2)
+    macroManager.editor.container.hidden = false
+    modalMode.toggle(true, { onDismiss: macroManager.hideEditor })
+  },
+  saveEditor () {
+    try {
+      const actions = JSON.parse(macroManager.editor.textarea.value)
+      macroManager.editor.macro.actions = actions
+      macroManager.save()
+      macroManager.renderList()
+      macroManager.hideEditor()
+    } catch (e) {
+      alert('Invalid JSON')
+    }
+  },
+  hideEditor () {
+    macroManager.editor.container.hidden = true
+    modalMode.toggle(false)
   }
 }
 

--- a/localization/languages/tr.json
+++ b/localization/languages/tr.json
@@ -146,8 +146,8 @@
     "settingsBlockedRequestCount": {
       "unsafeHTML": "Min şimdiye kadar, <strong></strong> reklam ve takipçi engelledi."
     },
-    "settingsCustomBangs": "Kişiselleştirilebilir Komutlar"
-    "settingsCustomBangsAdd": "Yeni komut ekle"
+    "settingsCustomBangs": "Kişiselleştirilebilir Komutlar",
+    "settingsCustomBangsAdd": "Yeni komut ekle",
     "settingsCustomBangsPhrase": "Cümle (Gerekli)",
     "settingsCustomBangsSnippet": "Açıklama (İsteğe Bağlı)",
     "settingsCustomBangsRedirect": "Yönlendirme URL'si (Gerekli)",

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -677,6 +677,10 @@ function createBang (bang, snippet, redirect) {
 const openMacroButton = document.getElementById('open-macro-manager')
 if (openMacroButton) {
   openMacroButton.addEventListener('click', function () {
-    window.parent.postMessage('showMacroManager', '*')
+    try {
+      window.parent.postMessage('showMacroManager', '*')
+    } catch (e) {
+      window.postMessage('showMacroManager', '*')
+    }
   })
 }


### PR DESCRIPTION
## Summary
- handle missing parent window when opening macro manager
- expand macro manager UI with editing and step-through console
- support recording macros with naming prompt

## Testing
- `node - <<'NODE'
const fs=require('fs');let data=fs.readFileSync('localization/languages/tr.json','utf8');data=data.replace(/\/\*[\s\S]*?\*\//g,'').replace(/(^|\s+)\/\/.*$/gm,'');JSON.parse(data);console.log('ok');
NODE`
- `npm test` *(fails: standard not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840e07e38c08327908271aed9969dcf