### PR TITLE
Fix macro manager recording

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,7 +155,7 @@
         ></button>
         <button
           id="macro-record-button"
-          class="navbar-action-button i carbon:record"
+          class="navbar-action-button i carbon:recording"
           title="Record Macro"
           tabindex="-1"
         ></button>
@@ -361,7 +361,7 @@
       <div id="macro-list"></div>
       <div class="macro-controls">
         <input id="macro-name" type="text" placeholder="Macro name" />
-        <button id="macro-record"><span class="i carbon:record"></span></button>
+        <button id="macro-record"><span class="i carbon:recording"></span></button>
         <button id="macro-play"><span class="i carbon:play"></span></button>
         <button id="macro-step"><span class="i carbon:chevron-right"></span></button>
       </div>

--- a/js/macroManager.js
+++ b/js/macroManager.js
@@ -138,6 +138,7 @@ const macroManager = {
         macroManager.save()
         macroManager.renderList()
       })
+      item.addEventListener('dblclick', () => macroManager.editMacro(macro))
       item.appendChild(name)
       item.appendChild(play)
       item.appendChild(step)
@@ -148,10 +149,10 @@ const macroManager = {
   },
   startRecording () {
     isRecording = true
-    recordingMacro = { name: macroManager.nameInput.value || 'macro', actions: [] }
+    recordingMacro = { name: '', actions: [] }
     macroManager.recordButton.textContent = 'Stop'
     if (macroManager.toolbarRecordButton) {
-      macroManager.toolbarRecordButton.classList.remove('carbon:record')
+      macroManager.toolbarRecordButton.classList.remove('carbon:recording')
       macroManager.toolbarRecordButton.classList.add('carbon:stop')
     }
     clickListener = function (e) {
@@ -170,13 +171,15 @@ const macroManager = {
     macroManager.recordButton.textContent = 'Record'
     if (macroManager.toolbarRecordButton) {
       macroManager.toolbarRecordButton.classList.remove('carbon:stop')
-      macroManager.toolbarRecordButton.classList.add('carbon:record')
+      macroManager.toolbarRecordButton.classList.add('carbon:recording')
     }
-    if (!recordingMacro.name || recordingMacro.name === 'macro') {
-      const name = prompt('Macro name:')
-      if (name) {
-        recordingMacro.name = name
-      }
+    let name = macroManager.nameInput.value
+    if (!name) {
+      name = prompt('Macro name:') || ''
+    }
+    if (name) {
+      recordingMacro.name = name
+      macroManager.nameInput.value = name
     }
     macroManager.macros.push(recordingMacro)
     macroManager.save()


### PR DESCRIPTION
## Summary
- change recording icon to `carbon:recording`
- double-click macro entries to open the editor
- prompt for macro name after recording if field empty

## Testing
- `npm test` *(fails: `standard: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6840ecb50b248327a64704a40a4e3134