### PR TITLE
Implement new macro system

### DIFF
--- a/css/macroManager.css
+++ b/css/macroManager.css
@@ -21,15 +21,30 @@
   gap: 0.5em;
 }
 
-#macro-editor textarea,
-#macro-step-console pre {
-  width: 100%;
-  height: 40vh;
+#macro-editor-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
   margin-top: 0.5em;
 }
 
-.macro-step-controls {
+#macro-steps {
+  margin-top: 1em;
+}
+
+.macro-step {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  margin-bottom: 0.5em;
+}
+
+.macro-step textarea {
+  flex: 1;
+}
+
+.macro-editor-controls {
   display: flex;
   gap: 0.5em;
-  margin-top: 0.5em;
+  margin-top: 1em;
 }

--- a/index.html
+++ b/index.html
@@ -360,27 +360,21 @@
       <button id="macro-close" class="modal-close-button i carbon:close"></button>
       <div id="macro-list"></div>
       <div class="macro-controls">
-        <input id="macro-name" type="text" placeholder="Macro name" />
-        <button id="macro-record"><span class="i carbon:recording"></span></button>
-        <button id="macro-play"><span class="i carbon:play"></span></button>
-        <button id="macro-step"><span class="i carbon:chevron-right"></span></button>
+        <button id="macro-create">Create Macro</button>
       </div>
     </div>
 
     <div id="macro-editor" class="modal" hidden>
       <h2 class="modal-title">Edit Macro</h2>
       <button id="macro-editor-close" class="modal-close-button i carbon:close"></button>
-      <textarea id="macro-editor-content" spellcheck="false"></textarea>
-      <button id="macro-editor-save">Save</button>
-    </div>
-
-    <div id="macro-step-console" class="modal" hidden>
-      <h2 class="modal-title">Step Macro</h2>
-      <button id="macro-step-close" class="modal-close-button i carbon:close"></button>
-      <pre id="macro-step-output"></pre>
-      <div class="macro-step-controls">
-        <button id="macro-step-next">Next (y)</button>
-        <button id="macro-step-stop">Stop</button>
+      <div id="macro-editor-fields">
+        <input id="macro-editor-name" type="text" placeholder="Name" />
+        <input id="macro-editor-description" type="text" placeholder="Description" />
+      </div>
+      <div id="macro-steps"></div>
+      <div class="macro-editor-controls">
+        <button id="macro-add-step">Add Step</button>
+        <button id="macro-editor-save">Save</button>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- replace old macro editor markup with step-based UI
- redesign macro CSS for step editing
- rebuild macroManager.js to support navigate/click/input/sleep/scroll/screenshot/run_js steps

## Testing
- `npm test` *(fails: standard not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840f501584c8327960cee0b60f4ef76