### PR TITLE
Add macOS theme tweaks

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -16,6 +16,18 @@
 body.mac * {
   letter-spacing: 0.4px;
 }
+body.mac {
+  background-color: #f5f5f7;
+  color: #000;
+  font-family: "-apple-system", "BlinkMacSystemFont", "Helvetica Neue", "Segoe UI", sans-serif;
+}
+body.mac button {
+  border-radius: 4px;
+  padding: 4px 8px;
+}
+body.mac button:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+}
 [hidden] {
   display: none !important;
 }

--- a/css/tabBar.css
+++ b/css/tabBar.css
@@ -437,3 +437,20 @@ body:not(.dark-theme) .progress-bar {
   transform: translateX(0%);
   transition: transform 500ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }
+
+/* macOS-inspired styling */
+body.mac #navbar {
+  background: linear-gradient(#fefefe, #e9e9e9);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  border-bottom-left-radius: 10px;
+  border-bottom-right-radius: 10px;
+}
+
+body.mac .tab-item {
+  border-radius: 6px;
+}
+
+body.mac .tab-item.active {
+  background-color: rgba(0, 0, 0, 0.07);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}


### PR DESCRIPTION
## Summary
- update base UI colors and fonts for macOS style
- tweak tab bar styling to look more like macOS

## Testing
- `npm test` *(fails: standard not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f03855f883279a8e8fd1325d70ce