### PR TITLE
Rename browser to Yuno and tweak macOS buttons

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -22,11 +22,21 @@ body.mac {
   font-family: "-apple-system", "BlinkMacSystemFont", "Helvetica Neue", "Segoe UI", sans-serif;
 }
 body.mac button {
-  border-radius: 4px;
+  -webkit-appearance: button;
+  border: 1px solid rgba(0, 0, 0, 0.25);
+  border-radius: 5px;
   padding: 4px 8px;
+  background-color: #f0f0f0;
+  transition: background-color 0.1s linear;
 }
 body.mac button:hover {
-  background-color: rgba(0, 0, 0, 0.05);
+  background-color: #eaeaea;
+}
+body.mac button:active {
+  background-color: #e0e0e0;
+}
+body.mac button:focus {
+  box-shadow: 0 0 0 2px rgba(0, 122, 255, 0.4);
 }
 [hidden] {
   display: none !important;

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="Content-Security-Policy" content="script-src 'self'" />
 
-    <title>Min</title>
+    <title>Yuno</title>
 
     <link rel="stylesheet" href="dist/bundle.css" />
     <link rel="stylesheet" href="ext/icons/iconfont.css" />

--- a/js/browserUI.js
+++ b/js/browserUI.js
@@ -148,7 +148,7 @@ function setWindowTitle (taskData) {
   if (taskData.name) {
     document.title = (taskData.name.length > 100 ? taskData.name.substring(0, 100) + '...' : taskData.name)
   } else {
-    document.title = 'Min'
+    document.title = 'Yuno'
   }
 }
 

--- a/main/menu.js
+++ b/main/menu.js
@@ -446,7 +446,7 @@ function buildAppMenu (options = {}) {
           label: l('appMenuAbout').replace('%n', app.name),
           click: function (item, window) {
             var info = [
-              'Min v' + app.getVersion(),
+              'Yuno v' + app.getVersion(),
               'Chromium v' + process.versions.chrome
             ]
             electron.dialog.showMessageBox({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "min",
-  "productName": "Min",
+  "name": "yuno",
+  "productName": "Yuno",
   "author": "PalmerAL",
   "version": "1.35.0",
   "description": "A fast, minimal browser that protects your privacy",


### PR DESCRIPTION
## Summary
- rename productName to **Yuno**
- update window title references
- show "Yuno" in About dialog
- style buttons with macOS look

## Testing
- `npm test` *(fails: standard not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f28aba5c832789c5ada7f61450fe